### PR TITLE
feat: injectable CachingSolver with external cache pre-population

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ pyrightconfig.json
 
 # Sphinx
 _build*
+CLAUDE.md
+AGENTS.md
+.claude/worktrees

--- a/bw_graph_tools/graph_traversal/base.py
+++ b/bw_graph_tools/graph_traversal/base.py
@@ -69,7 +69,7 @@ class BaseGraphTraversal(Generic[Settings]):
         self._nodes: Dict[int, Node] = {self._functional_unit_unique_id: self._root_node}
         self._edges: List[Edge] = []
         self._flows: List[Flow] = []
-        self._caching_solver = CachingSolver(lca)
+        self._caching_solver = settings.caching_solver or CachingSolver(lca)
 
     @property
     def nodes(self):

--- a/bw_graph_tools/graph_traversal/new_node_each_visit.py
+++ b/bw_graph_tools/graph_traversal/new_node_each_visit.py
@@ -1,6 +1,6 @@
 import warnings
 from heapq import heappop, heappush
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Any
 
 import matrix_utils as mu
 import numpy as np
@@ -17,7 +17,6 @@ from bw_graph_tools.graph_traversal.base import BaseGraphTraversal
 from bw_graph_tools.graph_traversal.graph_objects import Edge, Flow, Node
 from bw_graph_tools.graph_traversal.settings import GraphTraversalSettings
 from bw_graph_tools.graph_traversal.utils import (
-    CachingSolver,
     Counter,
     get_demand_vector_for_activity,
 )
@@ -408,7 +407,7 @@ class NewNodeEachVisitGraphTraversal(BaseGraphTraversal[GraphTraversalSettings])
         production_exchange_mapping: dict[int, int],
         static_activity_indices: set[int],
         separate_biosphere_flows: bool,
-        caching_solver: CachingSolver,
+        caching_solver: Any,
         biosphere_cutoff_score: float,
         cutoff_score: float,
         max_depth: Optional[int] = None,

--- a/bw_graph_tools/graph_traversal/new_node_each_visit.py
+++ b/bw_graph_tools/graph_traversal/new_node_each_visit.py
@@ -1,6 +1,6 @@
 import warnings
 from heapq import heappop, heappush
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional
 
 import matrix_utils as mu
 import numpy as np
@@ -17,6 +17,7 @@ from bw_graph_tools.graph_traversal.base import BaseGraphTraversal
 from bw_graph_tools.graph_traversal.graph_objects import Edge, Flow, Node
 from bw_graph_tools.graph_traversal.settings import GraphTraversalSettings
 from bw_graph_tools.graph_traversal.utils import (
+    CachingSolver,
     Counter,
     get_demand_vector_for_activity,
 )
@@ -407,7 +408,7 @@ class NewNodeEachVisitGraphTraversal(BaseGraphTraversal[GraphTraversalSettings])
         production_exchange_mapping: dict[int, int],
         static_activity_indices: set[int],
         separate_biosphere_flows: bool,
-        caching_solver: Any,
+        caching_solver: CachingSolver,
         biosphere_cutoff_score: float,
         cutoff_score: float,
         max_depth: Optional[int] = None,

--- a/bw_graph_tools/graph_traversal/settings.py
+++ b/bw_graph_tools/graph_traversal/settings.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Any
 
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import Annotated
@@ -34,6 +34,7 @@ class GraphTraversalSettings(BaseModel):
     max_depth: Optional[int] = None
     skip_coproducts: bool = False
     separate_biosphere_flows: bool = True
+    caching_solver: Any | None = None
 
     @model_validator(mode="after")
     def max_depth_positive(self):

--- a/bw_graph_tools/graph_traversal/utils.py
+++ b/bw_graph_tools/graph_traversal/utils.py
@@ -1,6 +1,3 @@
-from typing import Set
-from functools import lru_cache
-
 import numpy as np
 from bw2calc import LCA
 from scipy.sparse import spmatrix
@@ -15,12 +12,12 @@ class CachingSolver:
         self.lca = lca
         self._cache = {}
 
-    def in_cache(self, indices: Set[int]) -> set:
-        """Return all `indices` values which are in the cache"""
-        return indices.intersection(set(self._cache))
+    def in_cache(self, indices: set[int]) -> set[int]:
+        """Return all `indices` values which are in the cache."""
+        return indices & self._cache.keys()
 
     def add_to_cache(self, index: int, result: np.ndarray) -> None:
-        # Must be for a demand amount of 1!!!
+        """Store a pre-computed supply vector. Result must be for a demand amount of 1."""
         self._cache[index] = result
 
     def _calculate(self, index: int) -> np.ndarray:
@@ -28,14 +25,11 @@ class CachingSolver:
         self.lca.demand_array[index] = 1
         return self.lca.solve_linear_system()
 
-    @lru_cache(maxsize=8096)
     def calculate(self, index: int) -> np.ndarray:
-        """Compute cumulative LCA score for one unit of a given activity"""
-        try:
-            return self._cache[index]
-        except KeyError:
-            self.add_to_cache(index, self._calculate(index))
-            return self._cache[index]
+        """Compute cumulative LCA score for one unit of a given activity."""
+        if index not in self._cache:
+            self._cache[index] = self._calculate(index)
+        return self._cache[index]
 
     def __call__(self, index: int, amount: float) -> np.ndarray:
         return self.calculate(index) * amount

--- a/bw_graph_tools/graph_traversal/utils.py
+++ b/bw_graph_tools/graph_traversal/utils.py
@@ -1,3 +1,4 @@
+from typing import Set
 from functools import lru_cache
 
 import numpy as np
@@ -12,13 +13,29 @@ class CachingSolver:
 
     def __init__(self, lca: LCA):
         self.lca = lca
+        self._cache = {}
+
+    def in_cache(self, indices: Set[int]) -> set:
+        """Return all `indices` values which are in the cache"""
+        return indices.intersection(set(self._cache))
+
+    def add_to_cache(self, index: int, result: np.ndarray) -> None:
+        # Must be for a demand amount of 1!!!
+        self._cache[index] = result
+
+    def _calculate(self, index: int) -> np.ndarray:
+        self.lca.demand_array[:] = 0
+        self.lca.demand_array[index] = 1
+        return self.lca.solve_linear_system()
 
     @lru_cache(maxsize=8096)
     def calculate(self, index: int) -> np.ndarray:
         """Compute cumulative LCA score for one unit of a given activity"""
-        self.lca.demand_array[:] = 0
-        self.lca.demand_array[index] = 1
-        return self.lca.solve_linear_system()
+        try:
+            return self._cache[index]
+        except KeyError:
+            self.add_to_cache(index, self._calculate(index))
+            return self._cache[index]
 
     def __call__(self, index: int, amount: float) -> np.ndarray:
         return self.calculate(index) * amount

--- a/tests/traversal/test_caching_solver.py
+++ b/tests/traversal/test_caching_solver.py
@@ -1,0 +1,110 @@
+import numpy as np
+import pytest
+from bw2calc import LCA
+from bw2data import Database, Method
+from bw2data.tests import bw2test
+
+from bw_graph_tools import GraphTraversalSettings, NewNodeEachVisitGraphTraversal
+from bw_graph_tools.graph_traversal.utils import CachingSolver
+
+
+class MockLCA:
+    """Minimal LCA-like object for unit-testing CachingSolver without a real database."""
+
+    def __init__(self, size=5):
+        self.demand_array = np.zeros(size)
+
+    def solve_linear_system(self):
+        return self.demand_array.copy()
+
+
+def test_in_cache_empty():
+    solver = CachingSolver(MockLCA())
+    assert solver.in_cache({0, 1, 2}) == set()
+
+
+def test_in_cache_after_calculate():
+    solver = CachingSolver(MockLCA())
+    solver.calculate(2)
+    assert solver.in_cache({0, 1, 2}) == {2}
+    assert solver.in_cache({0, 1}) == set()
+
+
+def test_in_cache_after_add_to_cache():
+    solver = CachingSolver(MockLCA())
+    result = np.array([1.0, 2.0, 3.0])
+    solver.add_to_cache(7, result)
+    assert solver.in_cache({5, 6, 7}) == {7}
+    assert solver.in_cache({5, 6}) == set()
+
+
+def test_add_to_cache_is_returned_by_calculate():
+    """Pre-populated cache values are used by calculate, bypassing _calculate."""
+    solver = CachingSolver(MockLCA())
+    sentinel = np.array([99.0, 98.0, 97.0])
+    solver.add_to_cache(3, sentinel)
+    result = solver.calculate(3)
+    assert result is sentinel
+
+
+def test_add_to_cache_prevents_recalculation():
+    """calculate() should not call _calculate when the index is already cached."""
+    solver = CachingSolver(MockLCA())
+    sentinel = np.array([42.0])
+    solver.add_to_cache(0, sentinel)
+
+    called = []
+    original = solver._calculate
+    solver._calculate = lambda idx: called.append(idx) or original(idx)
+
+    solver.calculate(0)
+    assert called == [], "_calculate should not be called for a cached index"
+
+
+@bw2test
+def test_injected_caching_solver_is_used():
+    """A CachingSolver passed via settings is used instead of a fresh one."""
+    Database("bio").write(
+        {
+            ("bio", "a"): {"type": "emission", "name": "a", "exchanges": []},
+        }
+    )
+    Database("t").write(
+        {
+            ("t", "1"): {
+                "name": "1",
+                "exchanges": [
+                    {"input": ("bio", "a"), "amount": 1.0, "type": "biosphere"},
+                    {"input": ("t", "1"), "amount": 1, "type": "production"},
+                    {"input": ("t", "2"), "amount": 1, "type": "technosphere"},
+                ],
+            },
+            ("t", "2"): {
+                "name": "2",
+                "exchanges": [
+                    {"input": ("bio", "a"), "amount": 0.5, "type": "biosphere"},
+                    {"input": ("t", "2"), "amount": 1, "type": "production"},
+                ],
+            },
+        }
+    )
+    Method(("test",)).write([(("bio", "a"), 1)])
+
+    lca = LCA({("t", "1"): 1}, ("test",))
+    lca.lci()
+    lca.lcia()
+
+    # First traversal — build up a solver with a warm cache
+    gt1 = NewNodeEachVisitGraphTraversal(lca, GraphTraversalSettings())
+    gt1.traverse()
+    solver = gt1._caching_solver
+    cached_after_first = set(solver._cache.keys())
+    assert len(cached_after_first) > 0, "First traversal should populate the cache"
+
+    # Second traversal — inject the same solver
+    gt2 = NewNodeEachVisitGraphTraversal(
+        lca, GraphTraversalSettings(caching_solver=solver)
+    )
+    assert gt2._caching_solver is solver, "Injected solver should be used directly"
+    # Cache should already contain the indices from the first traversal
+    assert solver.in_cache(cached_after_first) == cached_after_first


### PR DESCRIPTION
## Summary

- Adds `caching_solver: Any | None` to `GraphTraversalSettings`, allowing callers to inject a pre-existing `CachingSolver` across multiple traversals and reuse already-computed supply vectors
- Refactors `CachingSolver` to use a manual `dict`-based cache, exposing `in_cache()` and `add_to_cache()` for external pre-population
- Removes the now-redundant `@lru_cache` decorator from `CachingSolver.calculate` (the dict cache already handles memoisation; `lru_cache` on instance methods also holds a strong reference to `self`, preventing GC)
- Fixes the solver injection: `BaseGraphTraversal.__init__` previously ignored `settings.caching_solver` and always created a fresh solver
- Restores precise `CachingSolver` type hint in `traverse_edges` (was weakened to `Any`)

## Test plan

- [ ] `test_in_cache_empty` — `in_cache` returns empty set when cache is cold
- [ ] `test_in_cache_after_calculate` — `in_cache` detects indices populated by `calculate`
- [ ] `test_in_cache_after_add_to_cache` — `in_cache` detects manually pre-populated indices
- [ ] `test_add_to_cache_is_returned_by_calculate` — pre-populated values are returned verbatim, bypassing `_calculate`
- [ ] `test_add_to_cache_prevents_recalculation` — `_calculate` is not called when the index is already in cache
- [ ] `test_injected_caching_solver_is_used` — end-to-end: solver passed via `GraphTraversalSettings` is wired up correctly in `BaseGraphTraversal.__init__`