### PR TITLE
ci: update test matrix to Python 3.10 and 3.14

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-13, macos-latest, windows-2019]
-        py-version: ["3.10", "3.12"]
+        py-version: ["3.10", "3.14"]
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Replace Python 3.12 with 3.14 in the CI test matrix
- Aligns test coverage to the oldest supported (3.10) and latest (3.14) Python versions

## Test plan
- [ ] Verify CI runs successfully on Python 3.10 and 3.14 across all OS targets