### PR TITLE
feat: warn when graph traversal coverage is below threshold

### DIFF
--- a/bw_graph_tools/graph_traversal/new_node_each_visit.py
+++ b/bw_graph_tools/graph_traversal/new_node_each_visit.py
@@ -337,6 +337,19 @@ class NewNodeEachVisitGraphTraversal(BaseGraphTraversal[GraphTraversalSettings])
         for key, obj in self._nodes.items():
             obj.terminal = key not in non_terminal_nodes
 
+        if self.lca.score != 0:
+            traversed_direct_score = sum(
+                node.direct_emissions_score
+                for node in self._nodes.values()
+                if node.unique_id != self._functional_unit_unique_id
+            )
+            coverage = traversed_direct_score / self.lca.score
+            if coverage < self.settings.min_coverage_fraction:
+                warnings.warn(
+                    f"Graph traversal covered only {coverage:.1%} of the total LCA score. "
+                    f"Consider lowering the `cutoff` (currently {self.settings.cutoff}) to improve coverage."
+                )
+
     @property
     def exceeded_calculation_count(self):
         return self.calculation_count > self._max_calc

--- a/bw_graph_tools/graph_traversal/settings.py
+++ b/bw_graph_tools/graph_traversal/settings.py
@@ -26,6 +26,10 @@ class GraphTraversalSettings(BaseModel):
     separate_biosphere_flows : bool
         Add separate `Flow` nodes for important individual biosphere
         emissions
+    min_coverage_fraction : float
+        Minimum fraction of the total LCA score that must be covered by the
+        traversed nodes. A warning is raised if coverage falls below this
+        value. Should be in `(0, 1]`. Default is 0.9.
     """
 
     cutoff: Annotated[float, Field(strict=True, gt=0, lt=1)] = 5e-3
@@ -35,6 +39,7 @@ class GraphTraversalSettings(BaseModel):
     skip_coproducts: bool = False
     separate_biosphere_flows: bool = True
     caching_solver: Any | None = None
+    min_coverage_fraction: Annotated[float, Field(strict=True, gt=0, le=1)] = 0.9
 
     @model_validator(mode="after")
     def max_depth_positive(self):


### PR DESCRIPTION
## Summary

- After `traverse()` completes, sum `direct_emissions_score` across all non-root nodes and compare to `lca.score`
- Emit a `warnings.warn` if coverage falls below `min_coverage_fraction` (default 0.9 / 90%)
- `min_coverage_fraction` is a new field on `GraphTraversalSettings`, validated to be in `(0, 1]`

Closes #7

## Test plan

- [ ] Verify warning fires when cutoff is set high enough that traversal covers < 90% of total score
- [ ] Verify no warning fires for a complete traversal
- [ ] Verify `min_coverage_fraction` can be adjusted via `GraphTraversalSettings`