### PR TITLE
fix: trigger PyPI deploy on any tag push

### DIFF
--- a/.github/workflows/python-package-deploy.yml
+++ b/.github/workflows/python-package-deploy.yml
@@ -6,6 +6,8 @@ name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 on:
   push:
     branches: [main, develop]
+    tags:
+      - "*"
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
@@ -14,7 +16,7 @@ jobs:
       id-token: write
     steps:
     - uses: actions/checkout@v6
-    - name: Set up Python 3.11
+    - name: Set up Python 3.14
       uses: actions/setup-python@v6
       with:
         python-version: "3.14"


### PR DESCRIPTION
Fixes #9

## Problem

The deploy workflow only triggered on pushes to `main`/`develop` branches. The `if: startsWith(github.ref, 'refs/tags')` guard on the PyPI publish step could therefore never be true — the workflow never ran on tag pushes at all.

## Changes

- Add `tags: ["*"]` to the `on.push` trigger so any tag push runs the workflow
- Fix cosmetic mismatch: step name "Set up Python 3.11" → "Set up Python 3.14"

## Behaviour after fix

| Event | TestPyPI | PyPI |
|---|---|---|
| Push to `main`/`develop` | ✓ | ✗ |
| Push any tag | ✓ | ✓ |