### PR TITLE
fix: SameNodeEachVisitTaggedGraphTraversal and reset_results bugs

### DIFF
--- a/bw_graph_tools/graph_traversal/new_node_each_visit.py
+++ b/bw_graph_tools/graph_traversal/new_node_each_visit.py
@@ -301,7 +301,8 @@ class NewNodeEachVisitGraphTraversal(BaseGraphTraversal[GraphTraversalSettings])
             self._nodes: Dict[int, Node] = {}
             self._edges: List[Edge] = []
             self._flows: List[Flow] = []
-        if self.calculation_count > 0:
+            self._max_calc = self.settings.max_calc
+        elif self.calculation_count > 0:
             # Have already done traversal; need to bump maximum number of maximum calculations
             self._max_calc += self.settings.max_calc
 

--- a/bw_graph_tools/graph_traversal/tagged_nodes.py
+++ b/bw_graph_tools/graph_traversal/tagged_nodes.py
@@ -261,10 +261,16 @@ class SameNodeEachVisitTaggedGraphTraversal(
         self, parent_node: Node, nodes: List[Node], tag_group: str
     ) -> int:
         """
-        Generate a consistent id for a grouped node
+        Generate a consistent id for a grouped node.
+
+        Uses only parent unique_id and tag label — depth is excluded because node
+        depth is reset to 0 when re-traversed, which would otherwise change the ID
+        and break the should_group_leaves idempotency check.  Uses 16 hex characters
+        (64-bit range) to avoid collisions with the sequential counter IDs used for
+        regular nodes (which start at 0 and count upward).
         """
-        label_parent_depth = "{}:{}:{}".format(parent_node.unique_id, nodes[0].depth, tag_group)
-        lookup = hashlib.sha256(label_parent_depth.encode()).hexdigest()[16]
+        label = "{}:{}".format(parent_node.unique_id, tag_group)
+        lookup = hashlib.sha256(label.encode()).hexdigest()[:16]
         return int(lookup, 16)
 
     def should_group_leaves(self, parent_node: Node, nodes: List[Node], tag_group: str) -> bool:
@@ -278,6 +284,10 @@ class SameNodeEachVisitTaggedGraphTraversal(
             if node.unique_id in self.visited_nodes:
                 return False
             self.visited_nodes.add(node.unique_id)
+            # Remove member unique_ids from visited_nodes so the
+            # SameNodeEachVisitGraphTraversal.traverse visited-check doesn't raise
+            # when we re-traverse the group's contents.
+            self.visited_nodes -= {n.unique_id for n in node.nodes}
             super().traverse(
                 nodes=node.nodes,
                 depth=depth,

--- a/tests/traversal/test_tagging_traversal.py
+++ b/tests/traversal/test_tagging_traversal.py
@@ -3,32 +3,41 @@ from itertools import groupby
 import bw2data as bd
 import pytest
 
-from bw_graph_tools import NewNodeEachVisitGraphTraversal
 from bw_graph_tools.graph_traversal import (
     GraphTraversalSettings,
+    NewNodeEachVisitGraphTraversal,
     NewNodeEachVisitTaggedGraphTraversal,
+    SameNodeEachVisitTaggedGraphTraversal,
     TaggedGraphTraversalSettings,
 )
 from bw_graph_tools.graph_traversal.graph_objects import Edge, GroupedNodes, Node
 from bw_graph_tools.graph_traversal.utils import Counter
 
 
-def get_default_graph(lca, tags):
-    return NewNodeEachVisitTaggedGraphTraversal(
+def get_default_graph(lca, tags, variant=NewNodeEachVisitTaggedGraphTraversal):
+    return variant(
         lca=lca,
         settings=TaggedGraphTraversalSettings(cutoff=0.001, max_calc=10, tags=tags),
     )
 
 
-def get_untagged_new_graph(lca):
-    return NewNodeEachVisitGraphTraversal(
-        lca=lca, settings=GraphTraversalSettings(cutoff=0.001, max_calc=10)
-    )
+def get_untagged_new_graph(lca, variant=NewNodeEachVisitGraphTraversal):
+    return variant(lca=lca, settings=GraphTraversalSettings(cutoff=0.001, max_calc=10))
 
 
 @pytest.fixture
 def graph(sample_database_with_tagged_products):
     g = get_default_graph(sample_database_with_tagged_products, ["test"])
+    yield g
+
+
+@pytest.fixture
+def same_node_graph(sample_database_with_tagged_products):
+    g = get_default_graph(
+        sample_database_with_tagged_products,
+        ["test"],
+        variant=SameNodeEachVisitTaggedGraphTraversal,
+    )
     yield g
 
 
@@ -200,3 +209,70 @@ class TestNewNodeTaggingTraversal:
 
         assert len(groups["test: group-a"][0].nodes) == 1
         assert len(groups["test: group-b"][0].nodes) == 3
+
+
+class TestSameNodeTaggingTraversal:
+    @staticmethod
+    def grouped_nodes(graph):
+        return [node for node in graph.nodes.values() if isinstance(node, GroupedNodes)]
+
+    def test_tagged_traversal(self, same_node_graph):
+        same_node_graph.traverse(depth=2)
+        assert len(same_node_graph.nodes) == 5
+        assert len(self.grouped_nodes(same_node_graph)) == 2
+
+        # find a single-member GroupedNodes dynamically instead of using a hardcoded ID
+        single_group = next(
+            gn for gn in self.grouped_nodes(same_node_graph) if len(gn.nodes) == 1
+        )
+        assert isinstance(single_group, GroupedNodes)
+
+        # expanding the grouped node replaces it with its actual child node
+        same_node_graph.traverse_from_node(single_group, depth=1)
+        assert len(self.grouped_nodes(same_node_graph)) == 1
+        assert len(same_node_graph.nodes) == 5
+
+    def test_traverse_from_node_returns_false_for_visited_grouped_node(self, same_node_graph):
+        same_node_graph.traverse(depth=2)
+        gn = self.grouped_nodes(same_node_graph)[0]
+
+        result_first = same_node_graph.traverse_from_node(gn, depth=1)
+        assert result_first is True
+
+        result_second = same_node_graph.traverse_from_node(gn, depth=1)
+        assert result_second is False
+
+    def test_traverse_from_node_regular_node(self, same_node_graph):
+        same_node_graph.traverse(depth=1)
+        # all non-root nodes at depth 1 are terminal, pick one that isn't a GroupedNode
+        regular_node = next(
+            node
+            for node in same_node_graph.nodes.values()
+            if node.unique_id != same_node_graph._functional_unit_unique_id
+            and not isinstance(node, GroupedNodes)
+            and node.terminal
+        )
+        result = same_node_graph.traverse_from_node(regular_node, depth=1)
+        assert result is True
+
+        # second call returns False — node already visited
+        result = same_node_graph.traverse_from_node(regular_node, depth=1)
+        assert result is False
+
+    def test_reset_does_not_inflate_max_calc(self, sample_database_with_tagged_products):
+        # Regression test for the bug fix in NewNodeEachVisitGraphTraversal.traverse:
+        # calling traverse(reset_results=True) after a prior traversal must restore
+        # _max_calc to settings.max_calc, not double it.
+        graph = get_untagged_new_graph(sample_database_with_tagged_products)
+        original_max_calc = graph._max_calc
+        graph.traverse()
+        # A continuation traverse (no reset) should bump the budget
+        assert graph.calculation_count > 0
+        graph.traverse()
+        assert graph._max_calc == original_max_calc * 2
+
+        # A reset traverse must restore the original budget, not keep doubling
+        graph.traverse(reset_results=True)
+        assert graph._max_calc == original_max_calc, (
+            "_max_calc was not restored after reset_results=True"
+        )


### PR DESCRIPTION
## Summary

Picks up the work from #22 (thanks @will7200) and fixes several bugs uncovered while writing tests.

### `new_node_each_visit.py` — correct the `reset_results` budget fix

PR #22 reset `_calculation_count.value = -1` to prevent `_max_calc` from doubling on `reset_results=True`. However, `_calculation_count` also serves as the node unique-ID generator, so resetting it causes ID collisions when a reset traversal re-encounters the same activity (broke `test_traversal_from_nodes_with_relative_depth`).

**Correct fix**: make `reset_results` and the continuation-bump branches mutually exclusive with `elif`, and reset `_max_calc` directly:

```python
if reset_results:
    …clear state…
    self._max_calc = self.settings.max_calc   # restore original budget
elif self.calculation_count > 0:
    self._max_calc += self.settings.max_calc  # bump only on continuation
```

### `tagged_nodes.py` — three bugs in `SameNodeEachVisitTaggedGraphTraversal`

1. **Hash collision** — `hexdigest()[16]` (one hex char) produces group IDs in 0–15, which collide with sequential traversal-node IDs. Fixed to use 16 hex chars (64-bit range).

2. **Unstable hash** — `depth` was included in the group ID hash, but `traverse(nodes=[...])` resets node depth to 0, so `should_group_leaves` generated a different ID and failed to suppress re-grouping after expansion. Fixed by removing depth from the hash; `parent_uid:tag_label` is sufficient since each node is visited at most once.

3. **`traverse_from_node` for `GroupedNodes` raised `GraphTraversalException`** — the group's members were already in `visited_nodes` (added when the initial traversal processed them as consumers), so the `SameNodeEachVisitGraphTraversal.traverse` guard raised on the first expansion attempt. Fixed by removing member unique-IDs from `visited_nodes` before delegating.

### `test_tagging_traversal.py` — test coverage

- Import cleanup (`NewNodeEachVisitGraphTraversal` from `bw_graph_tools.graph_traversal`)
- `get_default_graph` / `get_untagged_new_graph` accept a `variant` kwarg (from #22)
- `same_node_graph` fixture (from #22)
- `TestSameNodeTaggingTraversal`: tagged traversal with group expansion, `traverse_from_node` idempotency for `GroupedNodes`, `traverse_from_node` for regular nodes, `_max_calc` reset regression

## Test plan

- [ ] `pytest tests/traversal/test_tagging_traversal.py` — all 14 tests pass
- [ ] `pytest tests/` — 57 passed, 0 failed