### PR TITLE
Release 0.7

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7] - 2026-04-15
+
+* [#36 Injectable `CachingSolver` with external cache pre-population](https://github.com/brightway-lca/bw_graph_tools/pull/36): New `caching_solver` field on `GraphTraversalSettings` allows sharing a solver across multiple traversals; `CachingSolver` now exposes `in_cache()` and `add_to_cache()` for external pre-population
+* [#39 Warn when graph traversal coverage is below threshold](https://github.com/brightway-lca/bw_graph_tools/pull/39): New `min_coverage_fraction` field on `GraphTraversalSettings` (default 0.9); emits a warning if traversal covers less than the threshold fraction of total LCA score
+* [#38 Replace deprecated `np.in1d` with `np.isin`](https://github.com/brightway-lca/bw_graph_tools/pull/38): Fixes `AttributeError` with NumPy ≥ 2.0
+* [#32 Ensure `static_activity_indices` are added to the graph](https://github.com/brightway-lca/bw_graph_tools/pull/32)
+
 ## [0.6] - 2025-06-26
 
 * Remove Numpy `<2` version pin

--- a/bw_graph_tools/__init__.py
+++ b/bw_graph_tools/__init__.py
@@ -12,7 +12,7 @@ __all__ = (
     "to_normalized_adjacency_matrix",
 )
 
-__version__ = "0.6"
+__version__ = "0.7"
 
 from bw_graph_tools.graph_traversal import (
     AssumedDiagonalGraphTraversal,


### PR DESCRIPTION
## Summary

- Bump version to `0.7` in `bw_graph_tools/__init__.py`
- Add changelog entry for `0.7` covering PRs #32, #36, #38, #39

## Changes in this release

- [#36](https://github.com/brightway-lca/bw_graph_tools/pull/36) Injectable `CachingSolver` with external cache pre-population
- [#39](https://github.com/brightway-lca/bw_graph_tools/pull/39) Warn when graph traversal coverage is below `min_coverage_fraction`
- [#38](https://github.com/brightway-lca/bw_graph_tools/pull/38) Replace deprecated `np.in1d` with `np.isin` (fixes NumPy ≥ 2.0 compatibility)
- [#32](https://github.com/brightway-lca/bw_graph_tools/pull/32) Ensure `static_activity_indices` are added to the graph