### PR TITLE
Read explicit reference exchanges (gpe_zeroth_heuristic)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-* Add `gpe_zeroth_heuristic`, an authoritative production-exchange finder that reads explicit modeller-provided `reference` flags (`kind="reference"` resources from `bw_processing>=1.6`, exposed via `matrix_utils>=0.9`). It runs first in `guess_production_exchanges`, so any column with an explicit reference exchange is resolved directly instead of guessed — fixing co-production columns that the structural heuristics cannot disambiguate (see cauldron/brightway-api#739). Requires `bw_processing>=1.6` and `matrix_utils>=0.9`.
+* [#49](https://github.com/brightway-lca/bw_graph_tools/pull/49): Add `gpe_zeroth_heuristic`, an authoritative production-exchange finder that reads explicit modeller-provided `reference` flags (`kind="reference"` resources from `bw_processing>=1.6`, exposed via `matrix_utils>=0.9`). It runs first in `guess_production_exchanges`, so any column with an explicit reference exchange is resolved directly instead of guessed — fixing co-production columns that the structural heuristics cannot disambiguate (see cauldron/brightway-api#739). Requires `bw_processing>=1.6` and `matrix_utils>=0.9`.
 
 ## [0.9] - 2026-06-18
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+* Add `gpe_zeroth_heuristic`, an authoritative production-exchange finder that reads explicit modeller-provided `reference` flags (`kind="reference"` resources from `bw_processing>=1.6`, exposed via `matrix_utils>=0.9`). It runs first in `guess_production_exchanges`, so any column with an explicit reference exchange is resolved directly instead of guessed — fixing co-production columns that the structural heuristics cannot disambiguate (see cauldron/brightway-api#739). Requires `bw_processing>=1.6` and `matrix_utils>=0.9`.
+
 ## [0.9] - 2026-06-18
 
 * [#46 Batched multi-product graph-traversal scoring](https://github.com/brightway-lca/bw_graph_tools/pull/46): Each node's input products are now scored together in a single batched solve, reusing the cached matrix factorization for improved performance.

--- a/bw_graph_tools/matrix_tools.py
+++ b/bw_graph_tools/matrix_tools.py
@@ -47,6 +47,37 @@ def to_normalized_adjacency_matrix(
     return normalized
 
 
+def gpe_zeroth_heuristic(mm: mu.MappedMatrix) -> Tuple[np.ndarray, np.ndarray]:
+    """Use explicit reference-exchange flags to find production exchange indices.
+
+    If a resource group carries a ``reference`` boolean array (stored in the
+    datapackage with ``kind="reference"``), the entries flagged ``True`` are the
+    production/reference exchanges declared by the modeller. This is
+    authoritative: it is used in preference to all the structural heuristics,
+    which can only guess and cannot disambiguate e.g. co-production columns.
+
+    Operates on the masked resource-group data, so the returned values are matrix
+    indices. Resource groups without a reference array are silently ignored via
+    ``KeyError`` (mirroring ``gpe_second_heuristic``'s handling of ``flip``).
+
+    Returns a tuple of numpy integer matrix indices, rows by columns.
+    """
+    rows, cols = [], []
+
+    for group in mm.groups:
+        try:
+            reference = group.reference
+        except KeyError:
+            # No reference array given
+            continue
+        rows.append(group.row_masked[reference])
+        cols.append(group.col_masked[reference])
+
+    if rows:
+        return np.hstack(rows), np.hstack(cols)
+    return np.array([], dtype=np.int64), np.array([], dtype=np.int64)
+
+
 def gpe_first_heuristic(mm: mu.MappedMatrix) -> Tuple[np.ndarray, np.ndarray]:
     """Use first heuristic (same input and output ids) to find production exchange indices.
 
@@ -296,11 +327,16 @@ def guess_production_exchanges(mm: mu.MappedMatrix) -> Tuple[np.ndarray, np.ndar
 
     Try the following in order per activity (column):
 
+    * Explicit ``reference`` flag set by the modeller (authoritative)
     * Same input and output index
     * Single value where ``flip`` is negative
     * Single positive value
     * Single negative value (waste treatment)
     * Unique product across remaining unidentified columns
+
+    The first step reads explicit reference-exchange flags from the input data
+    packages; any column it identifies is treated as authoritative and is not
+    revisited by the structural heuristics that follow.
 
     Raises ``UnclearProductionExchange`` if these conditions are not met for any activity.
 
@@ -310,12 +346,25 @@ def guess_production_exchanges(mm: mu.MappedMatrix) -> Tuple[np.ndarray, np.ndar
     if mm.matrix.shape[0] == 0:
         raise ValueError("Empty matrix")
 
-    row_indices, col_indices = gpe_first_heuristic(mm)
+    # Authoritative: explicit modeller-provided reference flags win over all heuristics.
+    row_indices, col_indices = gpe_zeroth_heuristic(mm)
+
+    # First heuristic (shared input/output id). Drop any column already claimed
+    # authoritatively by the zeroth heuristic so we never contradict the modeller.
+    row_first, col_first = gpe_first_heuristic(mm)
+    if col_indices.size:
+        keep = ~np.isin(col_first, col_indices)
+        row_first, col_first = row_first[keep], col_first[keep]
+    row_indices = np.hstack([row_indices, row_first])
+    col_indices = np.hstack([col_indices, col_first])
 
     # Every column must have an activity with some reference product or the system
     # is not solvable. Therefore we can look across all columns. We will do
     # all the work in matrix indices.
-    missing = np.setdiff1d(np.arange(mm.matrix.shape[0]), col_indices, assume_unique=True)
+    # `col_indices` may contain a column more than once (e.g. a co-production
+    # column with several explicit reference exchanges), so we cannot assume the
+    # inputs are unique here.
+    missing = np.setdiff1d(np.arange(mm.matrix.shape[0]), col_indices)
 
     # Short circuit other steps if possible; assumption is that this step will
     # be taken for most matrices
@@ -331,7 +380,10 @@ def guess_production_exchanges(mm: mu.MappedMatrix) -> Tuple[np.ndarray, np.ndar
     if row_indices.shape != col_indices.shape:
         raise ValueError("Guessed row indices do not match guessed column indices.")
 
-    missing = np.setdiff1d(np.arange(mm.matrix.shape[0]), col_indices, assume_unique=True)
+    # `col_indices` may contain a column more than once (e.g. a co-production
+    # column with several explicit reference exchanges), so we cannot assume the
+    # inputs are unique here.
+    missing = np.setdiff1d(np.arange(mm.matrix.shape[0]), col_indices)
     if missing.size:
         raise UnclearProductionExchange(
             "Can't find production exchanges for columns: {}".format(list(missing))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ requires-python = ">=3.9"
 dependencies = [
     "bw2calc>=2.0.dev13",
     "bw2data>=4.0.dev46",
-    "bw_processing",
-    "matrix_utils",
+    "bw_processing>=1.6",
+    "matrix_utils>=0.9",
     "numpy<3",
     "pydantic",
     "scipy",

--- a/tests/test_zeroth_heuristic.py
+++ b/tests/test_zeroth_heuristic.py
@@ -1,0 +1,124 @@
+import bw_processing as bwp
+import matrix_utils as mu
+import numpy as np
+import pytest
+
+from bw_graph_tools.errors import UnclearProductionExchange
+from bw_graph_tools.matrix_tools import gpe_zeroth_heuristic, guess_production_exchanges
+
+
+def _pairs(row, col):
+    """Return the set of (row, col) matrix-index pairs, order-independent."""
+    return {(int(r), int(c)) for r, c in zip(row, col)}
+
+
+def test_gpe_zeroth_heuristic_basic():
+    dp = bwp.create_datapackage()
+    indices = np.array([(0, 0), (1, 0), (0, 1), (1, 1)], dtype=bwp.INDICES_DTYPE)
+    dp.add_persistent_vector(
+        matrix="test",
+        indices_array=indices,
+        name="foo",
+        data_array=np.array([1.0, 1.0, -1.0, -1.0]),
+        reference_array=np.array([True, False, False, True], dtype=bool),
+    )
+    mm = mu.MappedMatrix(packages=[dp], matrix="test")
+    row, col = gpe_zeroth_heuristic(mm)
+    assert _pairs(row, col) == {(0, 0), (1, 1)}
+
+
+def test_gpe_zeroth_heuristic_no_reference_array():
+    dp = bwp.create_datapackage()
+    indices = np.array([(0, 0), (1, 1)], dtype=bwp.INDICES_DTYPE)
+    dp.add_persistent_vector(
+        matrix="test",
+        indices_array=indices,
+        name="foo",
+        data_array=np.array([1.0, 1.0]),
+    )
+    mm = mu.MappedMatrix(packages=[dp], matrix="test")
+    row, col = gpe_zeroth_heuristic(mm)
+    assert row.shape == (0,)
+    assert col.shape == (0,)
+
+
+def test_gpe_zeroth_heuristic_multiple_dp_one_without_reference():
+    dp1 = bwp.create_datapackage()
+    dp1.add_persistent_vector(
+        matrix="test",
+        indices_array=np.array([(0, 0), (1, 0)], dtype=bwp.INDICES_DTYPE),
+        name="foo",
+        data_array=np.array([1.0, -1.0]),
+        reference_array=np.array([False, True], dtype=bool),
+    )
+    dp2 = bwp.create_datapackage()
+    dp2.add_persistent_vector(
+        matrix="test",
+        indices_array=np.array([(0, 1), (1, 1)], dtype=bwp.INDICES_DTYPE),
+        name="bar",
+        data_array=np.array([1.0, 1.0]),
+    )
+    mm = mu.MappedMatrix(packages=[dp1, dp2], matrix="test")
+    row, col = gpe_zeroth_heuristic(mm)
+    # Only dp1 carries reference flags; the flagged entry is (1, 0).
+    assert _pairs(row, col) == {(1, 0)}
+
+
+def test_guess_production_exchanges_reference_overrides_first_heuristic():
+    # Same product/activity id space, so the first (diagonal) heuristic would
+    # normally claim column 0 at row 0. An explicit reference flag on (1, 0)
+    # must win instead.
+    dp = bwp.create_datapackage()
+    indices = np.array([(0, 0), (1, 1), (1, 0)], dtype=bwp.INDICES_DTYPE)
+    dp.add_persistent_vector(
+        matrix="test",
+        indices_array=indices,
+        name="foo",
+        data_array=np.array([1.0, 1.0, 1.0]),
+        reference_array=np.array([False, False, True], dtype=bool),
+    )
+    mm = mu.MappedMatrix(packages=[dp], matrix="test")
+    row, col = guess_production_exchanges(mm)
+    # Column 0 -> row 1 (reference wins), column 1 -> row 1 (first heuristic).
+    assert dict(zip(col.tolist(), row.tolist())) == {0: 1, 1: 1}
+
+
+# The co-production loop that the structural heuristics cannot resolve:
+# activity A (col 20) produces product Y (row 10) and waste Z (row 11);
+# activity B (col 21) consumes Y and treats Z. Products and activities have
+# disjoint id spaces, both of A's exchanges are positive, and both of B's are
+# negative, so no sign/flip/uniqueness rule can pick the reference exchange.
+_LOOP_INDICES = np.array(
+    [(10, 20), (11, 20), (10, 21), (11, 21)], dtype=bwp.INDICES_DTYPE
+)
+_LOOP_DATA = np.array([1.0, 1.0, -1.0, -1.0])
+
+
+def test_guess_production_exchanges_coproduction_raises_without_reference():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="test",
+        indices_array=_LOOP_INDICES,
+        name="foo",
+        data_array=_LOOP_DATA,
+    )
+    mm = mu.MappedMatrix(packages=[dp], matrix="test")
+    with pytest.raises(UnclearProductionExchange):
+        guess_production_exchanges(mm)
+
+
+def test_guess_production_exchanges_coproduction_resolved_with_reference():
+    dp = bwp.create_datapackage()
+    dp.add_persistent_vector(
+        matrix="test",
+        indices_array=_LOOP_INDICES,
+        name="foo",
+        data_array=_LOOP_DATA,
+        # A's reference is Y (10, 20); B's reference is Z (11, 21).
+        reference_array=np.array([True, False, False, True], dtype=bool),
+    )
+    mm = mu.MappedMatrix(packages=[dp], matrix="test")
+    row, col = guess_production_exchanges(mm)
+    # rows 10/11 map to matrix rows 0/1, cols 20/21 map to matrix cols 0/1.
+    # Y (row 0) is A's (col 0) reference; Z (row 1) is B's (col 1) reference.
+    assert dict(zip(col.tolist(), row.tolist())) == {0: 0, 1: 1}


### PR DESCRIPTION
## Summary

Adds an authoritative production-exchange finder that reads **explicit modeller-provided reference flags** instead of guessing from matrix structure.

`bw_processing>=1.6` can store a per-exchange `reference` boolean side-resource (`kind="reference"`), and `matrix_utils>=0.9` exposes it as `ResourceGroup.reference`. This PR consumes it:

- **`gpe_zeroth_heuristic(mm)`** — returns the matrix indices of entries flagged `True`. Groups without a reference array are ignored (mirrors how `gpe_second_heuristic` handles `flip`).
- Wired in as the **first** step of `guess_production_exchanges`. Any column it claims is dropped from the first (diagonal) heuristic and skipped by the later ones, so an explicit reference always wins over a structural guess.
- Dropped `assume_unique=True` on the two `missing`-column `setdiff1d` calls, since a co-production column may now legitimately carry several reference exchanges (so `col_indices` is no longer guaranteed unique).

## Why

The five structural heuristics (matching ids, single non-flipped, single positive, single negative, unique product) are all inferences over signs/flip/uniqueness. They cannot resolve a **co-production column** whose products also appear elsewhere — e.g. activity A produces product Y and waste Z (both positive) while activity B consumes Y and treats Z (both negative). With disjoint product/activity id spaces, no heuristic can pick A's reference, and `guess_production_exchanges` raises `UnclearProductionExchange`. Only the modeller knows; this lets them record it. See cauldron/brightway-api#739 for the full write-up. It also subsumes the documented H3/H4 ordering limitation, since a flagged column is never revisited.

## Tests

`tests/test_zeroth_heuristic.py`: unit behavior (flagged pairs, no-reference → empty, multi-datapackage), authoritative override of the first heuristic, and the co-production loop that **raises `UnclearProductionExchange` without flags** and **resolves correctly with them**. Full suite: 91 passed, 2 skipped, 1 xfailed; all 35 existing heuristic tests still pass.

## Dependencies

Bumped to `bw_processing>=1.6` and `matrix_utils>=0.9` (the versions that produce and expose the `reference` resource).

## Context

Final repo in a three-part change: `bw_processing` #108 (merged) → `matrix_utils` #45 (merged, released in #46) → this. CI here needs `matrix_utils` 0.9 published.